### PR TITLE
Trailing slashes in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst setup.py THANKS
-recursive-include src/ *
-recursive-include docs/ *
-recursive-include benchmark/ *
+recursive-include src *
+recursive-include docs *
+recursive-include benchmark *


### PR DESCRIPTION
Trailing slashes in MANIFEST.in cause errors installing the package on Windows. They sould be removed.
