### PR TITLE
Ignore invalid UTF-8 characters.

### DIFF
--- a/misaka/utils.py
+++ b/misaka/utils.py
@@ -58,4 +58,4 @@ def deprecation(message):
 def to_string(buffer):
     if buffer == ffi.NULL or buffer.size == 0:
         return ''
-    return ffi.string(buffer.data, buffer.size).decode('utf-8')
+    return ffi.string(buffer.data, buffer.size).decode('utf-8', 'ignore')


### PR DESCRIPTION
When there is an invalid UTF-8, misaka will crash. Just ignore the invalids.