### PR TITLE
docs: fix simple typo, explit -> explicit

### DIFF
--- a/misaka/hoedown/document.h
+++ b/misaka/hoedown/document.h
@@ -77,7 +77,7 @@ typedef enum hoedown_table_flags {
 typedef enum hoedown_autolink_type {
 	HOEDOWN_AUTOLINK_NONE,		/* used internally when it is not an autolink*/
 	HOEDOWN_AUTOLINK_NORMAL,	/* normal http/http/ftp/mailto/etc link */
-	HOEDOWN_AUTOLINK_EMAIL		/* e-mail link without explit mailto: */
+	HOEDOWN_AUTOLINK_EMAIL		/* e-mail link without explicit mailto: */
 } hoedown_autolink_type;
 
 


### PR DESCRIPTION
There is a small typo in misaka/hoedown/document.h.

Should read `explicit` rather than `explit`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md